### PR TITLE
fix: functions.py -  delete serial number words

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -72,16 +72,8 @@ def did_record_prog(filePath, title, timestamp):
 def delete_serial(Path):
 	drm_regex = re.compile(r'（.*?）|［.*?］')
 	rtn_message = drm_regex.sub("", Path)
-	return (rtn_message)
+	return rtn_message.strip
 #
-
-# delete serial number words
-def delete_serial(Path):
-    drm_regex = re.compile(r'（.*?）|［.*?］')
-    rtn_message = drm_regex.sub("", Path)
-    return (rtn_message)
-#
-
 class DBXController():
 	hadInit = False
 	def __init__(self):


### PR DESCRIPTION
シリーズもののフォルダ名から番号を削除する関数のバグとり＋末尾のスペースを削除。