### PR TITLE
gRPCリクエストのログ出力機能の追加

### DIFF
--- a/cmd/recotod/main.go
+++ b/cmd/recotod/main.go
@@ -46,8 +46,13 @@ func main() {
         }
 
         srv := grpc.NewServer(
-                grpc.UnaryInterceptor(middleware.NewLoggerInterceptor(logger)),
-                grpc.StreamInterceptor(middleware.NewStreamLoggerInterceptor(logger)),
+                grpc.UnaryInterceptor(middleware.ChainUnaryInterceptors(
+                        middleware.NewLoggerInterceptor(logger),
+                        middleware.NewRequestLoggerInterceptor(logger),
+                )),
+                grpc.StreamInterceptor(middleware.ChainStreamInterceptors(
+                        middleware.NewStreamRequestLoggerInterceptor(logger),
+                )),
         )
         healthv1.RegisterHealthServiceServer(
                 srv,

--- a/cmd/recotod/main.go
+++ b/cmd/recotod/main.go
@@ -2,60 +2,61 @@
 package main
 
 import (
-	"fmt"
-	"net"
+        "fmt"
+        "net"
 
-	"github.com/samber/lo"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
+        "github.com/samber/lo"
+        "go.uber.org/zap"
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/reflection"
 
-	"github.com/sun-yryr/recoto/internal/adapter/grpcserver"
-	"github.com/sun-yryr/recoto/internal/adapter/grpcserver/middleware"
-	"github.com/sun-yryr/recoto/internal/broker"
-	"github.com/sun-yryr/recoto/internal/broker/nats"
-	"github.com/sun-yryr/recoto/internal/config"
-	"github.com/sun-yryr/recoto/internal/logger"
-	healthv1 "github.com/sun-yryr/recoto/pkg/api/recoto/health/v1"
+        "github.com/sun-yryr/recoto/internal/adapter/grpcserver"
+        "github.com/sun-yryr/recoto/internal/adapter/grpcserver/middleware"
+        "github.com/sun-yryr/recoto/internal/broker"
+        "github.com/sun-yryr/recoto/internal/broker/nats"
+        "github.com/sun-yryr/recoto/internal/config"
+        "github.com/sun-yryr/recoto/internal/logger"
+        healthv1 "github.com/sun-yryr/recoto/pkg/api/recoto/health/v1"
 )
 
 func main() {
-	// Load configuration
-	cfg := lo.Must(config.Load())
+        // Load configuration
+        cfg := lo.Must(config.Load())
 
-	// Initialize logger
-	logger := lo.Must(logger.NewLogger(cfg))
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			logger.Error("failed to sync logger", zap.Error(err))
-		}
-	}()
+        // Initialize logger
+        logger := lo.Must(logger.NewLogger(cfg))
+        defer func() {
+                if err := logger.Sync(); err != nil {
+                        logger.Error("failed to sync logger", zap.Error(err))
+                }
+        }()
 
-	logger.Info("Starting server...")
+        logger.Info("Starting server...")
 
-	// Initialize NATS broker
-	embBroker, err := nats.NewEmbeddedBroker()
-	if err != nil {
-		logger.Fatal("failed to create broker", zap.Error(err))
-	}
+        // Initialize NATS broker
+        embBroker, err := nats.NewEmbeddedBroker()
+        if err != nil {
+                logger.Fatal("failed to create broker", zap.Error(err))
+        }
 
-	// Initialize server
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Server.Port))
-	if err != nil {
-		logger.Fatal("failed to listen", zap.Error(err))
-	}
+        // Initialize server
+        lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Server.Port))
+        if err != nil {
+                logger.Fatal("failed to listen", zap.Error(err))
+        }
 
-	srv := grpc.NewServer(
-		grpc.UnaryInterceptor(middleware.NewLoggerInterceptor(logger)),
-	)
-	healthv1.RegisterHealthServiceServer(
-		srv,
-		grpcserver.NewHealthService(embBroker, broker.NewHealthCheck(embBroker)),
-	)
-	reflection.Register(srv)
+        srv := grpc.NewServer(
+                grpc.UnaryInterceptor(middleware.NewLoggerInterceptor(logger)),
+                grpc.StreamInterceptor(middleware.NewStreamLoggerInterceptor(logger)),
+        )
+        healthv1.RegisterHealthServiceServer(
+                srv,
+                grpcserver.NewHealthService(embBroker, broker.NewHealthCheck(embBroker)),
+        )
+        reflection.Register(srv)
 
-	// Start server
-	if err := srv.Serve(lis); err != nil {
-		logger.Fatal("failed to serve", zap.Error(err))
-	}
+        // Start server
+        if err := srv.Serve(lis); err != nil {
+                logger.Fatal("failed to serve", zap.Error(err))
+        }
 }

--- a/internal/adapter/grpcserver/middleware/chain.go
+++ b/internal/adapter/grpcserver/middleware/chain.go
@@ -1,0 +1,38 @@
+// Package middleware は、gRPCサーバーのミドルウェアを提供する
+package middleware
+
+import (
+        "context"
+
+        "google.golang.org/grpc"
+)
+
+// ChainUnaryInterceptors は、複数のUnaryServerInterceptorを1つのインターセプターにチェーンする。
+func ChainUnaryInterceptors(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+        return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+                // 最後のインターセプターから順に実行するチェーンを構築
+                chainHandler := handler
+                for i := len(interceptors) - 1; i >= 0; i-- {
+                        i := i // ループ変数をキャプチャ
+                        chainHandler = func(currentCtx context.Context, currentReq interface{}) (interface{}, error) {
+                                return interceptors[i](currentCtx, currentReq, info, chainHandler)
+                        }
+                }
+                return chainHandler(ctx, req)
+        }
+}
+
+// ChainStreamInterceptors は、複数のStreamServerInterceptorを1つのインターセプターにチェーンする。
+func ChainStreamInterceptors(interceptors ...grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
+        return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+                // 最後のインターセプターから順に実行するチェーンを構築
+                chainHandler := handler
+                for i := len(interceptors) - 1; i >= 0; i-- {
+                        i := i // ループ変数をキャプチャ
+                        chainHandler = func(currentSrv interface{}, currentStream grpc.ServerStream) error {
+                                return interceptors[i](currentSrv, currentStream, info, chainHandler)
+                        }
+                }
+                return chainHandler(srv, stream)
+        }
+}

--- a/internal/adapter/grpcserver/middleware/logger.go
+++ b/internal/adapter/grpcserver/middleware/logger.go
@@ -2,24 +2,118 @@
 package middleware
 
 import (
-	"context"
+        "context"
+        "time"
 
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
+        "go.uber.org/zap"
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/codes"
+        "google.golang.org/grpc/status"
 
-	"github.com/sun-yryr/recoto/internal/logger"
+        "github.com/sun-yryr/recoto/internal/logger"
 )
 
 // NewLoggerInterceptor は、ctxにLoggerを追加するUnaryServerInterceptorを返す。
 func NewLoggerInterceptor(zapLogger *zap.Logger) grpc.UnaryServerInterceptor {
-	return func(
-		ctx context.Context,
-		req interface{},
-		_ *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler,
-	) (interface{}, error) {
-		ctx = logger.WithLogger(ctx, zapLogger)
+        return func(
+                ctx context.Context,
+                req interface{},
+                info *grpc.UnaryServerInfo,
+                handler grpc.UnaryHandler,
+        ) (interface{}, error) {
+                ctx = logger.WithLogger(ctx, zapLogger)
+                startTime := time.Now()
 
-		return handler(ctx, req)
-	}
+                // リクエスト情報をログに出力
+                zapLogger.Info("gRPC request received",
+                        zap.String("method", info.FullMethod),
+                        zap.Any("request", req),
+                )
+
+                // ハンドラを実行
+                resp, err := handler(ctx, req)
+
+                // レスポンス情報をログに出力
+                duration := time.Since(startTime)
+                if err != nil {
+                        st, _ := status.FromError(err)
+                        zapLogger.Error("gRPC request failed",
+                                zap.String("method", info.FullMethod),
+                                zap.String("status_code", st.Code().String()),
+                                zap.String("status_message", st.Message()),
+                                zap.Duration("duration", duration),
+                                zap.Error(err),
+                        )
+                } else {
+                        zapLogger.Info("gRPC request completed",
+                                zap.String("method", info.FullMethod),
+                                zap.String("status_code", codes.OK.String()),
+                                zap.Duration("duration", duration),
+                                zap.Any("response", resp),
+                        )
+                }
+
+                return resp, err
+        }
+}
+
+// NewStreamLoggerInterceptor は、ストリーミングリクエスト用のロガーインターセプターを返す。
+func NewStreamLoggerInterceptor(zapLogger *zap.Logger) grpc.StreamServerInterceptor {
+        return func(
+                srv interface{},
+                stream grpc.ServerStream,
+                info *grpc.StreamServerInfo,
+                handler grpc.StreamHandler,
+        ) error {
+                startTime := time.Now()
+                
+                // ストリーミングリクエスト開始をログに出力
+                zapLogger.Info("gRPC streaming request started",
+                        zap.String("method", info.FullMethod),
+                        zap.Bool("is_client_stream", info.IsClientStream),
+                        zap.Bool("is_server_stream", info.IsServerStream),
+                )
+
+                // コンテキストにロガーを追加したラッパーストリームを作成
+                ctx := logger.WithLogger(stream.Context(), zapLogger)
+                wrappedStream := &wrappedServerStream{
+                        ServerStream: stream,
+                        ctx:          ctx,
+                }
+
+                // ハンドラを実行
+                err := handler(srv, wrappedStream)
+
+                // ストリーミングリクエスト終了をログに出力
+                duration := time.Since(startTime)
+                if err != nil {
+                        st, _ := status.FromError(err)
+                        zapLogger.Error("gRPC streaming request failed",
+                                zap.String("method", info.FullMethod),
+                                zap.String("status_code", st.Code().String()),
+                                zap.String("status_message", st.Message()),
+                                zap.Duration("duration", duration),
+                                zap.Error(err),
+                        )
+                } else {
+                        zapLogger.Info("gRPC streaming request completed",
+                                zap.String("method", info.FullMethod),
+                                zap.String("status_code", codes.OK.String()),
+                                zap.Duration("duration", duration),
+                        )
+                }
+
+                return err
+        }
+}
+
+// wrappedServerStream は、コンテキストを上書きするServerStreamラッパー
+type wrappedServerStream struct {
+        grpc.ServerStream
+        ctx context.Context
+}
+
+// Context は、ラップされたコンテキストを返す
+func (w *wrappedServerStream) Context() context.Context {
+        return w.ctx
 }

--- a/internal/adapter/grpcserver/middleware/request_logger.go
+++ b/internal/adapter/grpcserver/middleware/request_logger.go
@@ -1,0 +1,98 @@
+// Package middleware は、gRPCサーバーのミドルウェアを提供する
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// NewRequestLoggerInterceptor は、gRPCリクエストをログに記録するUnaryServerInterceptorを返す。
+func NewRequestLoggerInterceptor(zapLogger *zap.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		startTime := time.Now()
+
+		// リクエスト情報をログに出力
+		zapLogger.Info("gRPC request received",
+			zap.String("method", info.FullMethod),
+			zap.Any("request", req),
+		)
+
+		// ハンドラを実行
+		resp, err := handler(ctx, req)
+
+		// レスポンス情報をログに出力
+		duration := time.Since(startTime)
+		if err != nil {
+			st, _ := status.FromError(err)
+			zapLogger.Error("gRPC request failed",
+				zap.String("method", info.FullMethod),
+				zap.String("status_code", st.Code().String()),
+				zap.String("status_message", st.Message()),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			zapLogger.Info("gRPC request completed",
+				zap.String("method", info.FullMethod),
+				zap.String("status_code", codes.OK.String()),
+				zap.Duration("duration", duration),
+				zap.Any("response", resp),
+			)
+		}
+
+		return resp, err
+	}
+}
+
+// NewStreamRequestLoggerInterceptor は、ストリーミングリクエスト用のロガーインターセプターを返す。
+func NewStreamRequestLoggerInterceptor(zapLogger *zap.Logger) grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		startTime := time.Now()
+		
+		// ストリーミングリクエスト開始をログに出力
+		zapLogger.Info("gRPC streaming request started",
+			zap.String("method", info.FullMethod),
+			zap.Bool("is_client_stream", info.IsClientStream),
+			zap.Bool("is_server_stream", info.IsServerStream),
+		)
+
+		// ハンドラを実行
+		err := handler(srv, stream)
+
+		// ストリーミングリクエスト終了をログに出力
+		duration := time.Since(startTime)
+		if err != nil {
+			st, _ := status.FromError(err)
+			zapLogger.Error("gRPC streaming request failed",
+				zap.String("method", info.FullMethod),
+				zap.String("status_code", st.Code().String()),
+				zap.String("status_message", st.Message()),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			zapLogger.Info("gRPC streaming request completed",
+				zap.String("method", info.FullMethod),
+				zap.String("status_code", codes.OK.String()),
+				zap.Duration("duration", duration),
+			)
+		}
+
+		return err
+	}
+}


### PR DESCRIPTION
## 変更内容

- gRPCリクエストの開始時と完了時にInfoレベルでログを出力するように変更
- エラー発生時にはErrorレベルでログを出力
- ストリーミングリクエスト用のインターセプターも追加
- 既存のLoggerをcontextに含めるインターセプターとは別に実装

## 詳細

- リクエスト開始時にメソッド名とリクエスト内容をログ出力
- リクエスト完了時にメソッド名、ステータスコード、処理時間、レスポンス内容をログ出力
- エラー発生時にはエラー内容も含めてログ出力
- ストリーミングリクエストにも対応
- 複数のインターセプターをチェーンするためのユーティリティ関数を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - gRPCサーバーに複数のインターセプターを連結して実行できるチェーン機能を追加しました。
  - ストリーミングRPCリクエストの詳細なログ記録が可能なストリームインターセプターを導入しました。
  - ユニタリーおよびストリーミングRPCリクエストのリクエスト・レスポンス内容、エラー、処理時間を詳細に記録する構造化ログ機能を強化しました。

- **改善**
  - ログの粒度と情報量が向上し、トラブルシューティングや監査がより容易になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->