### PR TITLE
Implement afero-based file system and update tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.11.2
 	github.com/nats-io/nats.go v1.41.2
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.10.0
 	github.com/u2takey/ffmpeg-go v0.5.0
 	go.uber.org/zap v1.27.0
@@ -22,9 +23,8 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-        github.com/pmezard/go-difflib v1.0.0 // indirect
-        github.com/spf13/afero v1.14.0 // indirect
-        github.com/u2takey/go-utils v0.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/u2takey/go-utils v0.3.1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,9 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/u2takey/go-utils v0.3.1 // indirect
+        github.com/pmezard/go-difflib v1.0.0 // indirect
+        github.com/spf13/afero v1.14.0 // indirect
+        github.com/u2takey/go-utils v0.3.1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
+github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -48,7 +48,12 @@ func NewDefaultConfig() *Config {
 
 // GetDefaultConfigPath はデフォルトの設定ファイルパスを返す。
 func GetDefaultConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
+	return GetDefaultConfigPathFS(fileutil.NewOsFS())
+}
+
+// GetDefaultConfigPathFS は指定されたファイルシステムを使用してデフォルトの設定ファイルパスを返す。
+func GetDefaultConfigPathFS(filesystem fileutil.FileSystem) (string, error) {
+	home, err := filesystem.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get home directory")
 	}
@@ -58,11 +63,15 @@ func GetDefaultConfigPath() (string, error) {
 
 // LoadConfig は設定ファイルから設定を読み込む。存在しない場合はデフォルト設定を作成する。
 func LoadConfig(configPath string) (*Config, error) {
+	return LoadConfigFS(fileutil.NewOsFS(), configPath)
+}
+
+// LoadConfigFS は指定されたファイルシステムから設定ファイルを読み込む。存在しない場合はデフォルト設定を作成する。
+func LoadConfigFS(filesystem fileutil.FileSystem, configPath string) (*Config, error) {
 	var err error
 
-	// 設定ファイルのパスを決定
 	if configPath == "" {
-		configPath, err = GetDefaultConfigPath()
+		configPath, err = GetDefaultConfigPathFS(filesystem)
 		if err != nil {
 			return nil, err
 		}
@@ -70,16 +79,14 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	config := NewDefaultConfig()
 
-	// ファイルが存在するか確認
-	_, err = os.Stat(configPath)
-	if os.IsNotExist(err) {
-		// ディレクトリが存在することを確認
+	_, err = filesystem.Stat(configPath)
+	if errors.Is(err, os.ErrNotExist) {
 		dir := filepath.Dir(configPath)
-		if err := os.MkdirAll(dir, fileutil.DefaultDirPerm); err != nil {
+		if err := filesystem.MkdirAll(dir, fileutil.DefaultDirPerm); err != nil {
 			return nil, errors.Wrap(err, "failed to create config directory")
 		}
 
-		if err := SaveConfig(configPath, config); err != nil {
+		if err := SaveConfigFS(filesystem, configPath, config); err != nil {
 			return nil, err
 		}
 
@@ -88,7 +95,7 @@ func LoadConfig(configPath string) (*Config, error) {
 		return nil, errors.Wrap(err, "failed to check config file")
 	}
 
-	data, err := os.ReadFile(configPath) //nolint:gosec
+	data, err := filesystem.ReadFile(configPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read config file")
 	}
@@ -102,6 +109,11 @@ func LoadConfig(configPath string) (*Config, error) {
 
 // SaveConfig は設定をファイルに保存する。
 func SaveConfig(configPath string, config *Config) error {
+	return SaveConfigFS(fileutil.NewOsFS(), configPath, config)
+}
+
+// SaveConfigFS は指定されたファイルシステムに設定を保存する。
+func SaveConfigFS(filesystem fileutil.FileSystem, configPath string, config *Config) error {
 	if err := ValidateConfig(config); err != nil {
 		return errors.Wrap(err, "failed to validate config")
 	}
@@ -111,7 +123,7 @@ func SaveConfig(configPath string, config *Config) error {
 		return errors.Wrap(err, "failed to marshal config")
 	}
 
-	if err := os.WriteFile(configPath, data, fileutil.DefaultFilePerm); err != nil {
+	if err := filesystem.WriteFile(configPath, data, fileutil.DefaultFilePerm); err != nil {
 		return errors.Wrap(err, "failed to write config file")
 	}
 

--- a/internal/config/server/config_test.go
+++ b/internal/config/server/config_test.go
@@ -15,18 +15,18 @@ import (
 
 type statErrorFS struct{ fileutil.FileSystem }
 
-func (statErrorFS) Stat(string) (os.FileInfo, error) { return nil, errStat }
+func (*statErrorFS) Stat(string) (os.FileInfo, error) { return nil, errStat }
 
 type writeErrorFS struct{ fileutil.FileSystem }
 
-func (writeErrorFS) WriteFile(string, []byte, os.FileMode) error { return errWrite }
+func (*writeErrorFS) WriteFile(string, []byte, os.FileMode) error { return errWrite }
 
 var (
 	errStat  = errors.New("stat error")
 	errWrite = errors.New("write error")
 )
 
-const testConfigPath = "/config.toml"
+const testConfigPath = "/tmp/recoto/config.toml"
 
 func TestNewDefaultConfig(t *testing.T) {
 	t.Parallel()
@@ -39,9 +39,9 @@ func TestNewDefaultConfig(t *testing.T) {
 }
 
 func TestGetDefaultConfigPath(t *testing.T) {
-	fs := fileutil.NewMemFS()
-
 	t.Setenv("HOME", "/home/test")
+
+	fs := fileutil.NewMemFS()
 
 	path, err := GetDefaultConfigPathFS(fs)
 	require.NoError(t, err)
@@ -97,9 +97,9 @@ func TestLoadConfig_DefaultPath(t *testing.T) {
 	})
 
 	tempDir := t.TempDir()
-	fs := fileutil.NewMemFS()
-
 	t.Setenv("HOME", tempDir)
+
+	fs := fileutil.NewMemFS()
 	// デフォルトパスに設定ファイルを作成
 	configDir := filepath.Join(tempDir, ".config", "recoto")
 	require.NoError(t, fs.MkdirAll(configDir, 0o755))
@@ -149,7 +149,7 @@ func TestLoadConfig_StatError(t *testing.T) {
 	t.Parallel()
 
 	fs := statErrorFS{fileutil.NewMemFS()}
-	_, err := LoadConfigFS(fs, testConfigPath)
+	_, err := LoadConfigFS(&fs, testConfigPath)
 	require.Error(t, err)
 }
 
@@ -304,7 +304,7 @@ func TestSaveConfig_WriteError(t *testing.T) {
 	ro := writeErrorFS{mem}
 	cfg := NewDefaultConfig()
 
-	err := SaveConfigFS(ro, testConfigPath, cfg)
+	err := SaveConfigFS(&ro, testConfigPath, cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write config file")
 }

--- a/internal/config/server/config_test.go
+++ b/internal/config/server/config_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,7 +9,24 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sun-yryr/recoto/internal/fileutil"
 )
+
+type statErrorFS struct{ fileutil.FileSystem }
+
+func (statErrorFS) Stat(string) (os.FileInfo, error) { return nil, errStat }
+
+type writeErrorFS struct{ fileutil.FileSystem }
+
+func (writeErrorFS) WriteFile(string, []byte, os.FileMode) error { return errWrite }
+
+var (
+	errStat  = errors.New("stat error")
+	errWrite = errors.New("write error")
+)
+
+const testConfigPath = "/config.toml"
 
 func TestNewDefaultConfig(t *testing.T) {
 	t.Parallel()
@@ -21,42 +39,35 @@ func TestNewDefaultConfig(t *testing.T) {
 }
 
 func TestGetDefaultConfigPath(t *testing.T) {
-	t.Parallel()
+	fs := fileutil.NewMemFS()
 
-	path, err := GetDefaultConfigPath()
+	t.Setenv("HOME", "/home/test")
+
+	path, err := GetDefaultConfigPathFS(fs)
 	require.NoError(t, err)
 
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
-
-	expectedPath := filepath.Join(homeDir, ".config", "recoto", "daemon.toml")
+	expectedPath := filepath.Join("/home/test", ".config", "recoto", "daemon.toml")
 	assert.Equal(t, expectedPath, path)
 }
 
 func TestLoadConfig_FileNotExists(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-
-	// 存在しないファイルパスを指定
-	configPath := filepath.Join(tempDir, "config.toml")
-
-	// 設定を読み込む
-	cfg, err := LoadConfig(configPath)
+	fs := fileutil.NewMemFS()
+	cfg, err := LoadConfigFS(fs, testConfigPath)
 	require.NoError(t, err)
 
-	// デフォルト値が設定されていることを確認
 	assert.Equal(t, "info", cfg.Log.Level)
-	assert.FileExists(t, configPath)
+
+	_, statErr := fs.Stat(testConfigPath)
+	assert.NoError(t, statErr)
 }
 
 func TestLoadConfig_FileExists(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-
-	// テスト用の設定ファイルを作成
-	configPath := filepath.Join(tempDir, "config.toml")
+	fs := fileutil.NewMemFS()
+	configPath := testConfigPath
 	configContent := `
 [log]
 level = "error"
@@ -68,10 +79,8 @@ port = 9090
 save_dir = "/custom/path"
 `
 
-	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
-
-	// 設定を読み込む
-	cfg, err := LoadConfig(configPath)
+	require.NoError(t, fs.WriteFile(configPath, []byte(configContent), 0o600))
+	cfg, err := LoadConfigFS(fs, configPath)
 	require.NoError(t, err)
 
 	assert.Equal(t, "error", cfg.Log.Level)
@@ -88,11 +97,12 @@ func TestLoadConfig_DefaultPath(t *testing.T) {
 	})
 
 	tempDir := t.TempDir()
-	t.Setenv("HOME", tempDir)
+	fs := fileutil.NewMemFS()
 
+	t.Setenv("HOME", tempDir)
 	// デフォルトパスに設定ファイルを作成
 	configDir := filepath.Join(tempDir, ".config", "recoto")
-	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, fs.MkdirAll(configDir, 0o755))
 
 	configPath := filepath.Join(configDir, "daemon.toml")
 	configContent := `
@@ -105,10 +115,9 @@ port = 7070
 [recording]
 save_dir = "/test/dir"
 `
-	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+	require.NoError(t, fs.WriteFile(configPath, []byte(configContent), 0o600))
 
-	// 空のパスを指定してデフォルトパスから読み込む
-	cfg, err := LoadConfig("")
+	cfg, err := LoadConfigFS(fs, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "debug", cfg.Log.Level)
@@ -119,10 +128,8 @@ save_dir = "/test/dir"
 func TestLoadConfig_InvalidTOML(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-
-	// 不正なTOML形式の設定ファイルを作成
-	configPath := filepath.Join(tempDir, "config.toml")
+	fs := fileutil.NewMemFS()
+	configPath := testConfigPath
 	invalidContent := `
 [log]
 level = "error"
@@ -131,10 +138,9 @@ level = "error"
 port = "not a number" # 整数であるべき
 `
 
-	require.NoError(t, os.WriteFile(configPath, []byte(invalidContent), 0o600))
+	require.NoError(t, fs.WriteFile(configPath, []byte(invalidContent), 0o600))
 
-	// 設定を読み込む
-	_, err := LoadConfig(configPath)
+	_, err := LoadConfigFS(fs, configPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to unmarshal config")
 }
@@ -142,14 +148,8 @@ port = "not a number" # 整数であるべき
 func TestLoadConfig_StatError(t *testing.T) {
 	t.Parallel()
 
-	// ファイルのチェックが失敗するケース
-	// これはOSによって振る舞いが異なるため、全環境で動作するようにはしにくい
-	// 例えば、アクセス権のないディレクトリ内のファイルなど
-	configPath := "/root/.impossible/config.toml" // 通常のユーザーではアクセスできないパス
-
-	// 設定を読み込む試行
-	_, err := LoadConfig(configPath)
-	// エラーが発生することだけ確認
+	fs := statErrorFS{fileutil.NewMemFS()}
+	_, err := LoadConfigFS(fs, testConfigPath)
 	require.Error(t, err)
 }
 
@@ -243,10 +243,8 @@ func TestValidateConfig(t *testing.T) {
 func TestSaveConfig(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-
-	// 設定ファイルのパス
-	configPath := filepath.Join(tempDir, "config.toml")
+	fs := fileutil.NewMemFS()
+	configPath := testConfigPath
 
 	// テスト用の設定
 	cfg := &Config{
@@ -261,13 +259,11 @@ func TestSaveConfig(t *testing.T) {
 		},
 	}
 
-	// 設定を保存
-	require.NoError(t, SaveConfig(configPath, cfg))
-	// 設定ファイルが作成されていることを確認
-	require.FileExists(t, configPath)
+	require.NoError(t, SaveConfigFS(fs, configPath, cfg))
+	_, statErr := fs.Stat(configPath)
+	require.NoError(t, statErr)
 
-	// 設定を読み込む
-	loadedCfg, err := LoadConfig(configPath)
+	loadedCfg, err := LoadConfigFS(fs, configPath)
 	require.NoError(t, err)
 
 	// 保存した値が正しく読み込まれていることを確認
@@ -279,8 +275,8 @@ func TestSaveConfig(t *testing.T) {
 func TestSaveConfig_InvalidConfig(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "config.toml")
+	fs := fileutil.NewMemFS()
+	configPath := testConfigPath
 
 	// 無効な設定
 	invalidCfg := &Config{
@@ -296,7 +292,7 @@ func TestSaveConfig_InvalidConfig(t *testing.T) {
 	}
 
 	// 無効な設定で保存を試みる
-	err := SaveConfig(configPath, invalidCfg)
+	err := SaveConfigFS(fs, configPath, invalidCfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate config")
 }
@@ -304,13 +300,11 @@ func TestSaveConfig_InvalidConfig(t *testing.T) {
 func TestSaveConfig_WriteError(t *testing.T) {
 	t.Parallel()
 
-	// 書き込み権限のないパス
-	configPath := "/root/impossible_config.toml"
-
+	mem := fileutil.NewMemFS()
+	ro := writeErrorFS{mem}
 	cfg := NewDefaultConfig()
 
-	// 書き込み権限のないパスに保存を試みる
-	err := SaveConfig(configPath, cfg)
+	err := SaveConfigFS(ro, testConfigPath, cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write config file")
 }

--- a/internal/fileutil/fs.go
+++ b/internal/fileutil/fs.go
@@ -13,6 +13,8 @@ type FileSystem interface {
 	ReadFile(name string) ([]byte, error)
 	WriteFile(name string, data []byte, perm os.FileMode) error
 	MkdirAll(path string, perm os.FileMode) error
+	Remove(name string) error
+	Rename(oldpath, newpath string) error
 	UserHomeDir() (string, error)
 }
 
@@ -64,6 +66,22 @@ func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
 	if err := fs.Fs.MkdirAll(path, perm); err != nil {
 		return errors.Wrap(err, "mkdir failed")
+	}
+
+	return nil
+}
+
+func (fs *aferoFS) Remove(name string) error {
+	if err := fs.Fs.Remove(name); err != nil {
+		return errors.Wrap(err, "remove file failed")
+	}
+
+	return nil
+}
+
+func (fs *aferoFS) Rename(oldpath, newpath string) error {
+	if err := fs.Fs.Rename(oldpath, newpath); err != nil {
+		return errors.Wrap(err, "rename file failed")
 	}
 
 	return nil

--- a/internal/fileutil/fs.go
+++ b/internal/fileutil/fs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// FileSystem abstracts basic file operations.
+// FileSystem は基本的なファイル操作を抽象化します。
 type FileSystem interface {
 	Stat(name string) (os.FileInfo, error)
 	ReadFile(name string) ([]byte, error)
@@ -18,26 +18,23 @@ type FileSystem interface {
 	UserHomeDir() (string, error)
 }
 
-// aferoFS implements FileSystem using an underlying afero.Fs.
-type aferoFS struct {
+// AferoFS は基盤となるafero.Fsを使用してFileSystemを実装します。
+type AferoFS struct {
 	base afero.Fs
 }
 
-// NewOsFS returns a FileSystem implemented with the os filesystem.
-//
-//nolint:ireturn
-func NewOsFS() FileSystem {
-	return &aferoFS{base: afero.NewOsFs()}
+// NewOsFS はOSファイルシステムで実装されたAferoFSを返します。
+func NewOsFS() *AferoFS {
+	return &AferoFS{base: afero.NewOsFs()}
 }
 
-// NewMemFS returns a FileSystem implemented with an in-memory filesystem.
-//
-//nolint:ireturn
-func NewMemFS() FileSystem {
-	return &aferoFS{base: afero.NewMemMapFs()}
+// NewMemFS はインメモリファイルシステムで実装されたAferoFSを返します。
+func NewMemFS() *AferoFS {
+	return &AferoFS{base: afero.NewMemMapFs()}
 }
 
-func (fs *aferoFS) Stat(name string) (os.FileInfo, error) {
+// Stat は指定された名前のファイル情報を返します。
+func (fs *AferoFS) Stat(name string) (os.FileInfo, error) {
 	info, err := fs.base.Stat(name)
 	if err != nil {
 		return nil, errors.Wrap(err, "stat failed")
@@ -46,7 +43,8 @@ func (fs *aferoFS) Stat(name string) (os.FileInfo, error) {
 	return info, nil
 }
 
-func (fs *aferoFS) ReadFile(name string) ([]byte, error) {
+// ReadFile はファイル名で指定されたファイルを読み取り、その内容を返します。
+func (fs *AferoFS) ReadFile(name string) ([]byte, error) {
 	data, err := afero.ReadFile(fs.base, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "read file failed")
@@ -55,7 +53,8 @@ func (fs *aferoFS) ReadFile(name string) ([]byte, error) {
 	return data, nil
 }
 
-func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+// WriteFile は指定されたファイルにデータを書き込み、必要に応じてファイルを作成します。
+func (fs *AferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	if err := afero.WriteFile(fs.base, name, data, perm); err != nil {
 		return errors.Wrap(err, "write file failed")
 	}
@@ -63,7 +62,8 @@ func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
+// MkdirAll は指定されたパスのディレクトリを、必要な親ディレクトリと共に作成します。
+func (fs *AferoFS) MkdirAll(path string, perm os.FileMode) error {
 	if err := fs.base.MkdirAll(path, perm); err != nil {
 		return errors.Wrap(err, "mkdir failed")
 	}
@@ -71,7 +71,8 @@ func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
 	return nil
 }
 
-func (fs *aferoFS) Remove(name string) error {
+// Remove は指定されたファイルまたはディレクトリを削除します。
+func (fs *AferoFS) Remove(name string) error {
 	if err := fs.base.Remove(name); err != nil {
 		return errors.Wrap(err, "remove file failed")
 	}
@@ -79,7 +80,8 @@ func (fs *aferoFS) Remove(name string) error {
 	return nil
 }
 
-func (fs *aferoFS) Rename(oldpath, newpath string) error {
+// Rename はoldpathをnewpathに名前変更（移動）します。
+func (fs *AferoFS) Rename(oldpath, newpath string) error {
 	if err := fs.base.Rename(oldpath, newpath); err != nil {
 		return errors.Wrap(err, "rename file failed")
 	}
@@ -87,7 +89,8 @@ func (fs *aferoFS) Rename(oldpath, newpath string) error {
 	return nil
 }
 
-func (fs *aferoFS) UserHomeDir() (string, error) {
+// UserHomeDir は現在のユーザーのホームディレクトリを返します。
+func (fs *AferoFS) UserHomeDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "user home dir")

--- a/internal/fileutil/fs.go
+++ b/internal/fileutil/fs.go
@@ -1,0 +1,79 @@
+package fileutil
+
+import (
+	"os"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/afero"
+)
+
+// FileSystem abstracts basic file operations.
+type FileSystem interface {
+	Stat(name string) (os.FileInfo, error)
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm os.FileMode) error
+	MkdirAll(path string, perm os.FileMode) error
+	UserHomeDir() (string, error)
+}
+
+// aferoFS implements FileSystem using an underlying afero.Fs.
+type aferoFS struct {
+	afero.Fs
+}
+
+// NewOsFS returns a FileSystem implemented with the os filesystem.
+//
+//nolint:ireturn
+func NewOsFS() FileSystem {
+	return &aferoFS{Fs: afero.NewOsFs()}
+}
+
+// NewMemFS returns a FileSystem implemented with an in-memory filesystem.
+//
+//nolint:ireturn
+func NewMemFS() FileSystem {
+	return &aferoFS{Fs: afero.NewMemMapFs()}
+}
+
+func (fs *aferoFS) Stat(name string) (os.FileInfo, error) {
+	info, err := fs.Fs.Stat(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "stat failed")
+	}
+
+	return info, nil
+}
+
+func (fs *aferoFS) ReadFile(name string) ([]byte, error) {
+	data, err := afero.ReadFile(fs.Fs, name)
+	if err != nil {
+		return nil, errors.Wrap(err, "read file failed")
+	}
+
+	return data, nil
+}
+
+func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	if err := afero.WriteFile(fs.Fs, name, data, perm); err != nil {
+		return errors.Wrap(err, "write file failed")
+	}
+
+	return nil
+}
+
+func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
+	if err := fs.Fs.MkdirAll(path, perm); err != nil {
+		return errors.Wrap(err, "mkdir failed")
+	}
+
+	return nil
+}
+
+func (fs *aferoFS) UserHomeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "user home dir")
+	}
+
+	return home, nil
+}

--- a/internal/fileutil/fs.go
+++ b/internal/fileutil/fs.go
@@ -20,25 +20,25 @@ type FileSystem interface {
 
 // aferoFS implements FileSystem using an underlying afero.Fs.
 type aferoFS struct {
-	afero.Fs
+	base afero.Fs
 }
 
 // NewOsFS returns a FileSystem implemented with the os filesystem.
 //
 //nolint:ireturn
 func NewOsFS() FileSystem {
-	return &aferoFS{Fs: afero.NewOsFs()}
+	return &aferoFS{base: afero.NewOsFs()}
 }
 
 // NewMemFS returns a FileSystem implemented with an in-memory filesystem.
 //
 //nolint:ireturn
 func NewMemFS() FileSystem {
-	return &aferoFS{Fs: afero.NewMemMapFs()}
+	return &aferoFS{base: afero.NewMemMapFs()}
 }
 
 func (fs *aferoFS) Stat(name string) (os.FileInfo, error) {
-	info, err := fs.Fs.Stat(name)
+	info, err := fs.base.Stat(name)
 	if err != nil {
 		return nil, errors.Wrap(err, "stat failed")
 	}
@@ -47,7 +47,7 @@ func (fs *aferoFS) Stat(name string) (os.FileInfo, error) {
 }
 
 func (fs *aferoFS) ReadFile(name string) ([]byte, error) {
-	data, err := afero.ReadFile(fs.Fs, name)
+	data, err := afero.ReadFile(fs.base, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "read file failed")
 	}
@@ -56,7 +56,7 @@ func (fs *aferoFS) ReadFile(name string) ([]byte, error) {
 }
 
 func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	if err := afero.WriteFile(fs.Fs, name, data, perm); err != nil {
+	if err := afero.WriteFile(fs.base, name, data, perm); err != nil {
 		return errors.Wrap(err, "write file failed")
 	}
 
@@ -64,7 +64,7 @@ func (fs *aferoFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 }
 
 func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
-	if err := fs.Fs.MkdirAll(path, perm); err != nil {
+	if err := fs.base.MkdirAll(path, perm); err != nil {
 		return errors.Wrap(err, "mkdir failed")
 	}
 
@@ -72,7 +72,7 @@ func (fs *aferoFS) MkdirAll(path string, perm os.FileMode) error {
 }
 
 func (fs *aferoFS) Remove(name string) error {
-	if err := fs.Fs.Remove(name); err != nil {
+	if err := fs.base.Remove(name); err != nil {
 		return errors.Wrap(err, "remove file failed")
 	}
 
@@ -80,7 +80,7 @@ func (fs *aferoFS) Remove(name string) error {
 }
 
 func (fs *aferoFS) Rename(oldpath, newpath string) error {
-	if err := fs.Fs.Rename(oldpath, newpath); err != nil {
+	if err := fs.base.Rename(oldpath, newpath); err != nil {
 		return errors.Wrap(err, "rename file failed")
 	}
 


### PR DESCRIPTION
## Summary
- add afero-backed `FileSystem` abstraction
- refactor server config to use the new `FileSystem`
- rewrite config tests to use in-memory fs
- add missing afero dependency

## Testing
- `golangci-lint fmt ./...`
- `GOMODCACHE=$(go env GOMODCACHE) GOPROXY=off golangci-lint run ./...`
- `GOMODCACHE=$(go env GOMODCACHE) GOPROXY=off go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ファイルシステムの抽象化が導入され、OSファイルシステムやインメモリファイルシステムの切り替えが可能になりました。

- **リファクタリング**
  - 設定ファイルの読み書きやパス取得処理が、抽象化されたファイルシステムインターフェースを利用するようになりました。
  - テストがインメモリファイルシステムを用いて実行されるようになり、より柔軟なエラーシミュレーションが可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->