### PR TITLE
fileutil: SanitizeFilename関数でWindows予約語と空白の処理を追加

### DIFF
--- a/internal/fileutil/filename.go
+++ b/internal/fileutil/filename.go
@@ -12,15 +12,23 @@ var (
 	* macOS: / :
 	* Linux: /
 	 */
-	invalidCharsPattern = regexp.MustCompile(`[\\/:*?"<>|]`)
+	invalidCharsPattern = regexp.MustCompile(`[\\/:*?"<>|\s]`)
 	// 連続するアンダースコアを1つにまとめる。
 	multipleUnderscoresPattern = regexp.MustCompile(`_+`)
+	// Windows予約語のリスト
+	windowsReservedNames = []string{
+		"CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+	}
+	// 特殊なディレクトリ名
+	specialNames = []string{".", ".."}
 )
 
 // SanitizeFilename は、ファイル名に使用できない文字を安全な文字に置換する。
-// Windows、macOS、Linuxで共通して使用できない文字を処理する。
+// Windows、macOS、Linuxで共通して使用できない文字、Windows予約語、特殊名を処理する。
 func SanitizeFilename(filename string) string {
-	// 不正な文字をアンダースコアに置換
+	// 不正な文字（空白含む）をアンダースコアに置換
 	sanitized := invalidCharsPattern.ReplaceAllString(filename, "_")
 	// 連続するアンダースコアを1つにまとめる
 	sanitized = multipleUnderscoresPattern.ReplaceAllString(sanitized, "_")
@@ -29,6 +37,15 @@ func SanitizeFilename(filename string) string {
 	// 空文字列になった場合はデフォルト名を設定
 	if sanitized == "" {
 		sanitized = "recording"
+	}
+
+	// Windows予約語と特殊名のチェック
+	allReservedNames := append(windowsReservedNames, specialNames...)
+	for _, reserved := range allReservedNames {
+		if strings.EqualFold(sanitized, reserved) {
+			sanitized = "recording"
+			break
+		}
 	}
 
 	return sanitized

--- a/internal/fileutil/filename.go
+++ b/internal/fileutil/filename.go
@@ -16,12 +16,14 @@ var (
 	// 連続するアンダースコアを1つにまとめる。
 	multipleUnderscoresPattern = regexp.MustCompile(`_+`)
 	// Windows予約語のリスト。
+	//nolint:gochecknoglobals // パフォーマンス上の理由
 	windowsReservedNames = []string{
 		"CON", "PRN", "AUX", "NUL",
 		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
 		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 	}
 	// 特殊なディレクトリ名。
+	//nolint:gochecknoglobals // パフォーマンス上の理由
 	specialNames = []string{".", ".."}
 )
 

--- a/internal/fileutil/filename.go
+++ b/internal/fileutil/filename.go
@@ -15,13 +15,13 @@ var (
 	invalidCharsPattern = regexp.MustCompile(`[\\/:*?"<>|\s]`)
 	// 連続するアンダースコアを1つにまとめる。
 	multipleUnderscoresPattern = regexp.MustCompile(`_+`)
-	// Windows予約語のリスト
+	// Windows予約語のリスト。
 	windowsReservedNames = []string{
 		"CON", "PRN", "AUX", "NUL",
 		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
 		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 	}
-	// 特殊なディレクトリ名
+	// 特殊なディレクトリ名。
 	specialNames = []string{".", ".."}
 )
 
@@ -40,10 +40,14 @@ func SanitizeFilename(filename string) string {
 	}
 
 	// Windows予約語と特殊名のチェック
-	allReservedNames := append(windowsReservedNames, specialNames...)
+	allReservedNames := make([]string, 0, len(windowsReservedNames)+len(specialNames))
+	allReservedNames = append(allReservedNames, windowsReservedNames...)
+	allReservedNames = append(allReservedNames, specialNames...)
+
 	for _, reserved := range allReservedNames {
 		if strings.EqualFold(sanitized, reserved) {
 			sanitized = "recording"
+
 			break
 		}
 	}

--- a/internal/fileutil/filename_test.go
+++ b/internal/fileutil/filename_test.go
@@ -32,7 +32,7 @@ func TestSanitizeFilename(t *testing.T) {
 		{
 			name:     "filename with spaces",
 			filename: "  filename with spaces  ",
-			want:     "filename with spaces",
+			want:     "_filename_with_spaces_",
 		},
 		{
 			name:     "empty filename",
@@ -52,12 +52,57 @@ func TestSanitizeFilename(t *testing.T) {
 		{
 			name:     "filename with multiple consecutive spaces",
 			filename: "file  name  with    spaces",
-			want:     "file  name  with    spaces",
+			want:     "file_name_with_spaces",
 		},
 		{
 			name:     "filename with multiple consecutive underscores",
 			filename: "file__name___with____underscores",
 			want:     "file_name_with_underscores",
+		},
+		{
+			name:     "Windows reserved name - CON",
+			filename: "CON",
+			want:     "recording",
+		},
+		{
+			name:     "Windows reserved name - con (lowercase)",
+			filename: "con",
+			want:     "recording",
+		},
+		{
+			name:     "Windows reserved name - PRN",
+			filename: "PRN",
+			want:     "recording",
+		},
+		{
+			name:     "Windows reserved name - COM1",
+			filename: "COM1",
+			want:     "recording",
+		},
+		{
+			name:     "Windows reserved name - LPT9",
+			filename: "LPT9",
+			want:     "recording",
+		},
+		{
+			name:     "special directory name - dot",
+			filename: ".",
+			want:     "recording",
+		},
+		{
+			name:     "special directory name - double dot",
+			filename: "..",
+			want:     "recording",
+		},
+		{
+			name:     "valid filename with reserved substring",
+			filename: "CONtent",
+			want:     "CONtent",
+		},
+		{
+			name:     "filename with spaces becoming reserved after sanitization",
+			filename: "C O N",
+			want:     "C_O_N",
 		},
 	}
 


### PR DESCRIPTION
Windows予約語と特殊なファイル名の処理をSanitizeFilename関数に追加しました。

## 変更内容
- Windows予約語（CON, PRN, AUX, NUL, COM1-9, LPT1-9）のチェックを追加
- 特殊ディレクトリ名（., ..）のチェックを追加
- 空白文字も無効文字として置き換える処理を追加
- 大文字小文字を区別しない比較で予約語をチェック
- 既存テストを空白処理に合わせて更新
- Windows予約語と特殊名のテストケースを追加

Fixes #127

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ファイル名の空白文字がアンダースコアに置換されるようになりました。
  - Windowsの予約デバイス名や特別なディレクトリ名（例: CON, PRN, ".", ".."など）がファイル名として指定された場合、自動的に「recording」に置換されるようになりました。

- **テスト**
  - 新しいファイル名サニタイズ処理に対応したテストケースが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->