### PR TITLE
feat: サーバーのグレースフルシャットダウン処理の追加

### DIFF
--- a/cmd/recotod/main.go
+++ b/cmd/recotod/main.go
@@ -8,6 +8,9 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -127,7 +130,49 @@ func main() {
 
 	appLogger.Info("Server is listening on port", zap.Int("port", cfg.Server.Port))
 
-	if err := srv.Serve(lis); err != nil {
+	// シグナルハンドリングのためのチャネルを作成
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// 別のゴルーチンでサーバーを起動
+	serverErrCh := make(chan error, 1)
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			serverErrCh <- err
+		}
+	}()
+
+	// シグナルまたはサーバーエラーを待機
+	select {
+	case sig := <-sigCh:
+		appLogger.Info("received signal", zap.String("signal", sig.String()))
+	case err := <-serverErrCh:
 		appLogger.Fatal("failed to serve", zap.Error(err))
+	}
+
+	// グレースフルシャットダウンの実行
+	graceTimeout := 30 * time.Second
+	appLogger.Info("shutting down server", zap.Duration("timeout", graceTimeout))
+
+	// キャンセル用のコンテキストを作成（RecordingManagerのコンテキストをキャンセル）
+	cancel()
+
+	// サーバーのグレースフルシャットダウン
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(shutdownDone)
+	}()
+
+	// タイムアウト付きでシャットダウンを待機
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), graceTimeout)
+	defer shutdownCancel()
+
+	select {
+	case <-shutdownDone:
+		appLogger.Info("server shutdown completed")
+	case <-shutdownCtx.Done():
+		appLogger.Warn("server shutdown timed out, forcing stop")
+		srv.Stop()
 	}
 }


### PR DESCRIPTION
OSシグナル（SIGINT、SIGTERM）を捕捉して、gRPCサーバーとNATSサブスクライバーをグレースフルにシャットダウンする処理を実装しました。

## 変更内容
- シグナルハンドリング（SIGINT/SIGTERM）の追加
- gRPCサーバーの非同期起動とグレースフルシャットダウン
- RecordingManagerのコンテキストキャンセルによる録音停止
- 30秒のタイムアウト付きシャットダウン処理
- タイムアウト時の強制停止機能

## メリット
- 運用環境での安定性向上
- 進行中のリクエスト処理完了後の安全な終了
- リソースリークの防止

Closes #125

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サーバーの起動および終了処理が強化され、システムシグナル受信時に安全にシャットダウンできるようになりました。  
- **改善**
  - サーバー終了時に最大30秒間のグレースフルシャットダウンを試み、タイムアウト時は強制終了します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->